### PR TITLE
Сервис CashbackHackService при заданном граничном значении кратном 1_000 выдает необходимость покупки еще на 1_000 а не на 0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,9 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testImplementation 'org.testng:testng:7.1.0'
 }
 
 test {
-    useJUnitPlatform()
+    useTestNG()
 }

--- a/src/test/java/ru/netology/Service/CashbackHackServiceTest.java
+++ b/src/test/java/ru/netology/Service/CashbackHackServiceTest.java
@@ -1,0 +1,63 @@
+package ru.netology.Service;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class CashbackHackServiceTest {
+    CashbackHackService service = new CashbackHackService();
+
+    @Test
+    public void shouldCashbackHackServiceIf0() {
+        int amount = 0;
+        int expected = 1000;
+
+        assertEquals(service.remain(amount), expected);
+
+    }
+
+
+    @Test
+    public void shouldCashbackHackServiceBelow1000() {
+        int amount = 500;
+        int expected = 500;
+
+        assertEquals(service.remain(amount), expected);
+
+    }
+    @Test
+    public void shouldCashbackHackService999() {
+        int amount = 999;
+        int expected = 1;
+
+        assertEquals(service.remain(amount), expected);
+
+    }
+    @Test
+    public void shouldCashbackHackServiceBorder1000() {
+        int amount = 1_000;
+        int expected = 0;
+
+        assertEquals(service.remain(amount), expected);
+
+    }
+
+    @Test
+    public void shouldCashbackHackService1001() {
+        int amount = 1_001;
+        int expected = 999;
+
+        assertEquals(service.remain(amount), expected);
+
+    }
+
+    @Test
+    public void shouldCashbackHackServiceMore1000() {
+        int amount = 1_700;
+        int expected = 300;
+
+        assertEquals(service.remain(amount), expected);
+
+    }
+
+}


### PR DESCRIPTION
## Описание
Сервис CashbackHackService при заданном граничном значении кратном "1_000" выдает необходимость покупки еще на "1_000", а ожидаемое значение для данного действия "0".
## Шаги по воспроизведению:
1. Запустить сервис CashbackHackService
2. Установить сумму покупки кратной "1_000" (1_000)
3. Запустить расчёт

## Ожидаемый результат
При совершении покупки на сумму кратную "1_000", сервис должен предлагать докупить на "0".
## Фактический результат
При совершении покупки на сумму кратную "1_000", сервис предлагает докупить еще на "1_000".

## ПО

- ОС - Windows 7 максимальная x64;
- IntelliJ IDEA 2021.2.3 (Community Edition)
- Runtime version: 11.0.12+7-b1504.40 amd64

